### PR TITLE
Release:  Atualiza modelo e views de fotos para usar `type_photo` em vez de booleanos + ajustes no accounts

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -54,6 +54,7 @@ class User(AbstractUser):
     def __str__(self):
         return self.username
 
+
 class Location(models.Model):
     country = models.CharField(max_length=100)
     state = models.CharField(choices=STATE_CHOICES, max_length=3)
@@ -63,6 +64,7 @@ class Location(models.Model):
     street = models.CharField(max_length=100)
     number = models.IntegerField(null=True)
     complement = models.CharField(blank=True, null=True, max_length=250)
+
 
 class SocialMedia(models.Model):
     whatsapp = models.CharField(max_length=20, blank=True, null=True,
@@ -75,35 +77,35 @@ class SocialMedia(models.Model):
 
 class Establishment(models.Model):
     user = models.ForeignKey(
-        User, 
-        on_delete=models.CASCADE, 
+        User,
+        on_delete=models.CASCADE,
         related_name="establishment_user"
     )
-    name = models.CharField(max_length=100) 
+    name = models.CharField(max_length=100)
 
     description = models.TextField(null=True, blank=True)
-    
+
     cnpj = models.CharField(max_length=14)
 
     social_media = models.ForeignKey(
-        SocialMedia, 
-        on_delete=models.SET_NULL, 
-        null=True, 
-        blank=True, 
+        SocialMedia,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
         related_name="establishments_social_media"
     )
 
     location = models.ForeignKey(
-        Location, 
-        on_delete=models.PROTECT, 
+        Location,
+        on_delete=models.PROTECT,
         related_name="establishment_location"
     )
-    
+
     category = models.ManyToManyField(
-        Category, 
+        Category,
         related_name="establishments_category"
     )
-    
+
     pix_key = models.CharField(
         max_length=100,
         null=True,
@@ -114,12 +116,11 @@ class Establishment(models.Model):
     def __str__(self):
         return self.name
 
-    # Métodos de conveniência para acessar as fotos:
     def get_profile_photo(self):
-        return self.photos.filter(is_profile_pic=True).first()
+        return self.photos.filter(type_photo='profile').first()
 
     def get_gallery_photos(self):
-        return self.photos.filter(is_gallery_pic=True).all()
+        return self.photos.filter(type_photo='gallery').all()
 
     def get_product_photos(self):
-        return self.photos.filter(is_product_pic=True).all()
+        return self.photos.filter(type_photo='product').all()

--- a/photos/models.py
+++ b/photos/models.py
@@ -2,36 +2,58 @@ from django.db import models
 from accounts.models import Establishment
 
 
-#retorna um caminho tipo: photos/{id_do_estabelecimento}/profile/{nome_do_arquivo} o mesmo para os demais
 def upload_to_path(instance, filename):
-    if instance.is_profile_pic:
-        return f'photos/{instance.establishment.id}/profile/{filename}'
-    elif instance.is_gallery_pic:
-        return f'photos/{instance.establishment.id}/gallery/{filename}'
-    elif instance.is_product_pic:
-        return f'photos/{instance.establishment.id}/product/{filename}'
-    return f'photos/{instance.establishment.id}/others/{filename}'
-
+    folder = instance.type_photo if instance.type_photo in ['profile', 'gallery', 'product'] else 'others'
+    return f'photos/{instance.establishment.id}/{folder}/{filename}'
 
 class Photo(models.Model):
+    PROFILE = "profile"
+    GALLERY = "gallery"
+    PRODUCT = "product"
+
+    PHOTO_TYPES = [
+        (PROFILE, "Foto de Perfil"),
+        (GALLERY, "Galeria"),
+        (PRODUCT, "Produto"),
+    ]
+
     establishment = models.ForeignKey(
         Establishment,
         on_delete=models.CASCADE,
-        related_name='photos'  # Permite: estabelecimento.photos.all()
+        related_name='photos',
+        verbose_name="Estabelecimento"
     )
-    image = models.ImageField(upload_to=upload_to_path)
-    alt_text = models.CharField(max_length=255, blank=True, null=True)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    is_profile_pic = models.BooleanField(default=False)
-    is_gallery_pic = models.BooleanField(default=False)
-    is_product_pic = models.BooleanField(default=False)
+    image = models.ImageField(upload_to=upload_to_path, blank=True, null=True)
+    alt_text = models.CharField("Texto alternativo", max_length=255, blank=True, null=True)
+    created_at = models.DateTimeField("Criado em", auto_now_add=True)
+    updated_at = models.DateTimeField("Atualizado em", auto_now=True)
+    type_photo = models.CharField("Tipo da foto", max_length=20, choices=PHOTO_TYPES)
 
     class Meta:
         indexes = [
-            models.Index(fields=['establishment', 'is_profile_pic']),
-            models.Index(fields=['establishment', 'is_gallery_pic']),
-            models.Index(fields=['establishment', 'is_product_pic']),
+            models.Index(fields=['establishment', 'type_photo']),
         ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=['establishment'],
+                condition=models.Q(type_photo='profile'),
+                name='unique_profile_photo_per_establishment'
+            )
+        ]
+        verbose_name = "Foto"
+        verbose_name_plural = "Fotos"
 
+    def __str__(self):
+        return f"{self.establishment.name} - {self.get_type_photo_display()}"
+
+    @property
+    def is_profile_pic(self):
+        return self.type_photo == self.PROFILE
+
+    @property
+    def is_gallery_pic(self):
+        return self.type_photo == self.GALLERY
+
+    @property
+    def is_product_pic(self):
+        return self.type_photo == self.PRODUCT


### PR DESCRIPTION
# Atualiza modelo e views de fotos para usar `type_photo` em vez de booleanos + ajustes no accounts

## Descrição

Este pull request traz as seguintes atualizações importantes:

- **Refatoração do modelo `Photo`:**  
  Substituição dos campos booleanos (`is_profile_pic`, `is_gallery_pic`, `is_product_pic`) por um único campo `type_photo` com choices (`profile`, `gallery`, `product`), melhorando a organização e evitando inconsistências.

- **Ajustes nas views de upload de fotos:**  
  Atualização dos métodos para trabalhar com o campo `type_photo`, garantindo que apenas um tipo de foto seja marcado por vez e simplificando a lógica.

- **Correção nos métodos do modelo `Establishment` (accounts):**  
  Modificação dos métodos que buscam fotos para usarem o novo campo `type_photo`, adaptando a lógica à nova estrutura do modelo `Photo`.

- **Melhorias gerais:**  
  Código mais limpo, fácil manutenção e redução de erros causados por múltiplos campos booleanos para tipos de fotos.

---
