### PR TITLE
Refatora funcionalidades de fotos: upload múltiplo, validação e limite de tamanho

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -1,12 +1,14 @@
 import os
 from datetime import timedelta
 from pathlib import Path
-
 import dj_database_url
 from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+DATA_UPLOAD_MAX_MEMORY_SIZE = 10485760  # 10MB
+FILE_UPLOAD_MAX_MEMORY_SIZE = 10485760  # 10MB
 
 
 # Quick-start development settings - unsuitable for production

--- a/photos/serializers.py
+++ b/photos/serializers.py
@@ -1,11 +1,38 @@
 from rest_framework import serializers
 from photos.models import Photo
+from PIL import Image
+from PIL import UnidentifiedImageError
+
 
 class PhotoSerializer(serializers.ModelSerializer):
     image = serializers.ImageField(use_url=True)
 
     class Meta:
         model = Photo
-        fields = ['id', 'establishment', 'image', 'alt_text',
-                  'is_profile_pic', 'is_gallery_pic', 'is_product_pic']
-        read_only_fields = ['id']
+        fields = ['id', 'establishment', 'image', 'alt_text', 'type_photo']
+        read_only_fields = ['id', 'establishment']
+
+    def validate_image(self, value):
+
+        try:
+            img = Image.open(value)
+            img.verify()
+            value.seek(0)
+        except UnidentifiedImageError:
+            raise serializers.ValidationError(
+                "O arquivo enviado não é uma imagem válida.")
+        except Exception:
+            raise serializers.ValidationError("Erro ao processar a imagem.")
+
+        if value.size > 5 * 1024 * 1024:
+            raise serializers.ValidationError(
+                "A imagem deve ter no máximo 2MB.")
+
+        return value
+
+    def validate_type_photo(self, value):
+        allowed = ['profile', 'gallery', 'product']
+        if value not in allowed:
+            raise serializers.ValidationError(
+                f"Tipo de foto inválido. Deve ser um dos: {allowed}")
+        return value


### PR DESCRIPTION
# Refatora funcionalidades de fotos: upload múltiplo, validação e limite de tamanho

## Descrição

Este PR traz as seguintes atualizações na funcionalidade de fotos:

- Refatoração da `GalleryPhotoUploadView` para suportar upload múltiplo de imagens na galeria, com validação individual usando o serializer.
- Atualização do `PhotoSerializer` para incluir validação de tamanho máximo de 5MB para imagens do tipo `gallery`.
- Ajustes no model `Photo` para tornar obrigatório o campo de imagem.
- Configuração dos limites de upload no `settings.py` para evitar erros com arquivos grandes.

Essas mudanças melhoram a robustez, segurança e usabilidade do upload de fotos no sistema.
